### PR TITLE
allow to exclude keys from sorting, fixes #19

### DIFF
--- a/lib/deep_merge.rb
+++ b/lib/deep_merge.rb
@@ -31,13 +31,15 @@ module Hashie
         self
       end
 
-      def deep_sort_by_key_and_sort_array(&block)
+      def deep_sort_by_key_and_sort_array(exclusions = [], &block)
         self.keys.sort(&block).reduce({}) do |seed, key|
           seed[key] = self[key]
-          if seed[key].is_a?(Hash)
-            seed[key] = seed[key].deep_sort_by_key_and_sort_array(&block)
-          elsif seed[key].is_a?(Hashie::Array)
-            seed[key] = seed[key].sort(&block)
+          unless exclusions.include?(key.to_s)
+            if seed[key].is_a?(Hash)
+              seed[key] = seed[key].deep_sort_by_key_and_sort_array(exclusions, &block)
+            elsif seed[key].is_a?(Hashie::Array)
+              seed[key] = seed[key].sort(&block)
+            end
           end
           seed
         end

--- a/lib/orchparty/transformations/sort.rb
+++ b/lib/orchparty/transformations/sort.rb
@@ -3,7 +3,7 @@ module Orchparty
   module Transformations
     class Sort
       def transform(ast)
-        AST::Node.new ast.deep_sort_by_key_and_sort_array {|a, b| a.to_s <=> b.to_s }
+        AST::Node.new ast.deep_sort_by_key_and_sort_array(["command", "entrypoint"]) {|a, b| a.to_s <=> b.to_s }
       end
     end
   end

--- a/spec/input/example.rb
+++ b/spec/input/example.rb
@@ -51,6 +51,8 @@ application "web-example" do
 
   service "db" do
     image "postgres:latest"
+    # stupid command to test sorting
+    command ["postgres", "--localhost"]
     labels do
       label "com.example.longline": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaa"
       label "com.example.db":  "db label"

--- a/spec/output/docker_compose_v1/example.yml
+++ b/spec/output/docker_compose_v1/example.yml
@@ -1,5 +1,8 @@
 ---
 db:
+  command:
+  - postgres
+  - "--localhost"
   extra_hosts:
   - extra_host1
   - extra_host2

--- a/spec/output/docker_compose_v2/example.yml
+++ b/spec/output/docker_compose_v2/example.yml
@@ -2,6 +2,9 @@
 version: '2'
 services:
   db:
+    command:
+    - postgres
+    - "--localhost"
     extra_hosts:
     - extra_host1
     - extra_host2


### PR DESCRIPTION
This is a small hack for fixing #19 . I guess it's ok, when we find more keys that are not allowed to be sorted we have to add them manually.