### PR TITLE
Disable Hashie::Mash warnings.

### DIFF
--- a/lib/orchparty/ast.rb
+++ b/lib/orchparty/ast.rb
@@ -7,6 +7,7 @@ module Orchparty
       include Hashie::Extensions::DeepMergeConcat
       include Hashie::Extensions::MethodAccess
       include Hashie::Extensions::Mash::KeepOriginalKeys
+      disable_warnings
     end
 
     def self.hash(args = {})


### PR DESCRIPTION
We get many hundreds of lines of warning of this type in some of our projects:
"WARN -- : You are setting a key that conflicts with a built-in method Orchparty::AST::Node#size defined in Hash. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method."